### PR TITLE
Create CODEOWNERS file with default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS: specify people or teams responsible for changes
+# Format: path  @username-or-team
+# Use @srfrog as default owner for reviews. Adjust as needed.
+
+* @srfrog


### PR DESCRIPTION
Add CODEOWNERS file to specify default reviewers

### Summary

<!-- Brief description of the change -->

### Related issues
<!-- Link issue(s) if any, e.g. Fixes #123 -->

### Checklist
- [ ] I have run tests locally and they pass: `go test ./...`
- [ ] I have run linters: `gofmt -l .` / `golangci-lint run` (if available)
- [ ] I have added tests if applicable
- [ ] I have updated documentation if needed

### Notes for reviewers
<!-- Anything the reviewer should know; short and focused -->
