### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,8 @@ jobs:
 
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Potential fix for [https://github.com/srfrog/slices/security/code-scanning/2](https://github.com/srfrog/slices/security/code-scanning/2)

The correct fix is to add an explicit `permissions` block to minimize the GITHUB_TOKEN privileges. Since all jobs/steps in the workflow as shown only need to read repository contents (for checkout/build/test), the most secure minimal starting permissions are `contents: read`. The `permissions` key can be added either at the workflow root or at the `build` job level. For clarity and future extensibility, adding it at the job level is recommended in cases with multiple jobs needing different permissions, but in this case, either is acceptable since there's only one job. To match the example given in the flagged message and minimize disruption, add a `permissions:` block under the `build:` job, specifying `contents: read` immediately before the `runs-on:` line. No additional imports, definitions, or logic are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
